### PR TITLE
UCP/WIREUP: Don't discard CM lane

### DIFF
--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -1085,6 +1085,7 @@ ucp_wireup_check_config_intersect(ucp_ep_h ep,
         reuse_lane = reuse_lane_map[lane];
         if (reuse_lane == UCP_NULL_RESOURCE) {
             if (ep->uct_eps[lane] != NULL) {
+                ucs_assert(lane != ucp_ep_get_cm_lane(ep));
                 ucp_worker_discard_uct_ep(worker, ep->uct_eps[lane],
                                           UCT_FLUSH_FLAG_LOCAL,
                                           ucp_wireup_pending_purge_cb,

--- a/src/ucp/wireup/wireup_cm.c
+++ b/src/ucp/wireup/wireup_cm.c
@@ -762,37 +762,20 @@ static void ucp_cm_disconnect_cb(uct_ep_h uct_cm_ep, void *arg)
     uct_worker_cb_id_t prog_id = UCS_CALLBACKQ_ID_NULL;
     ucp_worker_h worker        = ucp_ep->worker;
     uct_ep_h uct_ep;
-    int discard_uct_ep;
 
     ucs_trace("ep %p: CM remote disconnect callback invoked, flags 0x%x",
               ucp_ep, ucp_ep->flags);
 
     uct_ep = ucp_ep_get_cm_uct_ep(ucp_ep);
-    if (uct_ep == NULL) {
-        UCS_ASYNC_BLOCK(&worker->async);
-        discard_uct_ep = ucp_worker_is_uct_ep_discarding(worker, uct_cm_ep);
-        UCS_ASYNC_UNBLOCK(&worker->async);
-
-        if (discard_uct_ep) {
-            /* The CM lane couldn't exist if the error was detected on the
-             * transport lane and all UCT lanes have already been discraded */
-            ucs_diag("ep %p: UCT EP %p for CM lane doesn't exist, it"
-                     " has already been discarded", ucp_ep, uct_cm_ep);
-            return;
-        }
-
-        ucs_fatal("ep %p: UCT EP for CM lane doesn't exist", ucp_ep);
-    }
-
     ucs_assertv_always(uct_cm_ep == uct_ep,
                        "%p: uct_cm_ep=%p vs found_uct_ep=%p",
                        ucp_ep, uct_cm_ep, uct_ep);
 
-    uct_worker_progress_register_safe(ucp_ep->worker->uct,
+    uct_worker_progress_register_safe(worker->uct,
                                       ucp_ep_cm_disconnect_progress,
                                       ucp_ep, UCS_CALLBACKQ_FLAG_ONESHOT,
                                       &prog_id);
-    ucp_worker_signal_internal(ucp_ep->worker);
+    ucp_worker_signal_internal(worker);
 }
 
 ucs_status_t ucp_ep_client_cm_create_uct_ep(ucp_ep_h ucp_ep)

--- a/test/gtest/ucp/test_ucp_worker.cc
+++ b/test/gtest/ucp/test_ucp_worker.cc
@@ -94,6 +94,8 @@ protected:
         ops.ep_destroy       = ep_destroy_func;
         iface.ops            = ops;
 
+        std::vector<uct_ep_h> eps_to_discard;
+
         for (unsigned i = 0; i < ep_count; i++) {
             uct_ep_h discard_ep;
 
@@ -145,7 +147,14 @@ protected:
                                  pending_reqs);
             }
 
+            eps_to_discard.push_back(discard_ep);
+        }
+
+        for (std::vector<uct_ep_h>::iterator iter = eps_to_discard.begin();
+             iter != eps_to_discard.end(); ++iter) {
+            uct_ep_h discard_ep        = *iter;
             unsigned purged_reqs_count = 0;
+
             ucp_worker_discard_uct_ep(sender().worker(), discard_ep,
                                       UCT_FLUSH_FLAG_LOCAL,
                                       ep_pending_purge_count_reqs_cb,
@@ -167,32 +176,38 @@ protected:
 
         void *flush_req = sender().flush_worker_nb(0);
 
-        ASSERT_FALSE(flush_req == NULL);
-        ASSERT_TRUE(UCS_PTR_IS_PTR(flush_req));
+        if (ep_flush_func != (void*)ucs_empty_function_return_success) {
+            /* If uct_ep_flush() returns UCS_OK from the first call, the request
+             * is not scheduled on a worker progress (it completes in-place) */
+            ASSERT_FALSE(flush_req == NULL);
+            ASSERT_TRUE(UCS_PTR_IS_PTR(flush_req));
 
-        do {
-            progress();
+            do {
+                progress();
 
-            if (!m_flush_comps.empty()) {
-                uct_completion_t *comp = m_flush_comps.back();
+                if (!m_flush_comps.empty()) {
+                    uct_completion_t *comp = m_flush_comps.back();
 
-                m_flush_comps.pop_back();
-                uct_invoke_completion(comp, UCS_OK);
-            }
-
-            if (!m_pending_reqs.empty()) {
-                uct_pending_req_t *req = m_pending_reqs.back();
-
-                status = req->func(req);
-                if (status == UCS_OK) {
-                    m_pending_reqs.pop_back();
-                } else {
-                    EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
+                    m_flush_comps.pop_back();
+                    uct_invoke_completion(comp, UCS_OK);
                 }
-            }
-        } while (ucp_request_check_status(flush_req) == UCS_INPROGRESS);
 
-        EXPECT_UCS_OK(ucp_request_check_status(flush_req));
+                if (!m_pending_reqs.empty()) {
+                    uct_pending_req_t *req = m_pending_reqs.back();
+
+                    status = req->func(req);
+                    if (status == UCS_OK) {
+                        m_pending_reqs.pop_back();
+                    } else {
+                        EXPECT_EQ(UCS_ERR_NO_RESOURCE, status);
+                    }
+                }
+            } while (ucp_request_check_status(flush_req) == UCS_INPROGRESS);
+
+            EXPECT_UCS_OK(ucp_request_check_status(flush_req));
+            ucp_request_release(flush_req);
+        }
+
         EXPECT_EQ(m_created_ep_count, m_destroyed_ep_count);
         EXPECT_EQ(m_created_ep_count, total_ep_count);
 
@@ -215,8 +230,6 @@ protected:
 
         EXPECT_TRUE(m_flush_comps.empty());
         EXPECT_TRUE(m_pending_reqs.empty());
-
-        ucp_request_release(flush_req);
 
         /* check that uct_ep_destroy() was called for the all EPs that
          * were created in the test */


### PR DESCRIPTION
## What

Don't discard CM lane.

## Why ?

Don't schedule UCT CM lane to be discarded, since UCP EP will be destroyed due to peer failure and `ucp_cm_disconnect_cb()` could be invoked on async thread after UCP EP is destroyed and before UCT CM EP is destroyed from discarding functionality. So, UCP EP will passed as a corrupted argument to `ucp_cm_disconnect_cb()`.
Fixes #5875

## How ?

Add `if` check into the `ucp_worker_iface_err_handle_progress()` to understand whether the lane is CM or not:
- if it is a CM lane, purge pending operations by calling `uct_ep_pending_purge()` and destroy UCT EP in-place by calling `uct_ep_destroy()`
- if it is not a CM lane, schedule UCT EP to be discarded
