### PR TITLE
UCP/TAG: add eager compatibility

### DIFF
--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -1462,6 +1462,11 @@ static ucs_status_t ucp_fill_config(ucp_context_h context,
         }
     }
 
+    if (context->config.ext.proto_enable) {
+        ucs_info("UCX_PROTO_ENABLE disabled for compatibilities reason");
+        context->config.ext.proto_enable = 0;
+    }
+
     if (context->config.ext.keepalive_num_eps == 0) {
         ucs_error("UCX_KEEPALIVE_NUM_EPS value must be greater than 0");
         status = UCS_ERR_INVALID_PARAM;

--- a/src/ucp/core/ucp_ep.c
+++ b/src/ucp/core/ucp_ep.c
@@ -1994,7 +1994,7 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
     size_t max_rndv_thresh, max_am_rndv_thresh;
     size_t min_rndv_thresh, min_am_rndv_thresh;
     size_t rma_zcopy_thresh;
-    size_t am_max_eager_short;
+    ssize_t am_max_eager_short;
     double get_zcopy_max_bw[UCS_MEMORY_TYPE_LAST];
     double put_zcopy_max_bw[UCS_MEMORY_TYPE_LAST];
     ucs_status_t status;
@@ -2194,6 +2194,9 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
             ucp_ep_config_set_memtype_thresh(&config->tag.offload.max_eager_short,
                                              config->tag.eager.max_short,
                                              context->num_mem_type_detect_mds);
+            /* TAG offload is disabled for compatibility reasons */
+            ucs_assert(config->tag.offload.max_eager_short.memtype_on < 0);
+            ucs_assert(config->tag.offload.max_eager_short.memtype_off < 0);
         }
     }
 
@@ -2261,7 +2264,13 @@ ucs_status_t ucp_ep_config_init(ucp_worker_h worker, ucp_ep_config_t *config,
                 /* TODO: set threshold level based on all available lanes */
 
                 config->tag.eager           = config->am;
-                config->tag.eager.max_short = am_max_eager_short;
+                /* short_iov which is used for compatibility path does not have
+                 * header, payload can be 8 bytes larger but we add ep_id to header,
+                 * so 8 - 16 = -8 bytes*/
+                config->tag.eager.max_short = (am_max_eager_short <
+                                               (ssize_t)sizeof(uint64_t)) ? -1 :
+                                              (am_max_eager_short -
+                                               sizeof(uint64_t));
                 config->tag.lane            = lane;
                 config->tag.rndv.am_thresh  = config->rndv.am_thresh;
                 config->tag.rndv.rma_thresh = config->rndv.rma_thresh;

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -24,18 +24,6 @@
 typedef void (*ucp_req_complete_func_t)(ucp_request_t *req, ucs_status_t status);
 
 
-static UCS_F_ALWAYS_INLINE void
-ucp_add_uct_iov_elem(uct_iov_t *iov, void *buffer, size_t length,
-                     uct_mem_h memh, size_t *iov_cnt)
-{
-    iov[*iov_cnt].buffer = buffer;
-    iov[*iov_cnt].length = length;
-    iov[*iov_cnt].count  = 1;
-    iov[*iov_cnt].stride = 0;
-    iov[*iov_cnt].memh   = memh;
-    ++(*iov_cnt);
-}
-
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_do_am_bcopy_single(uct_pending_req_t *self, uint8_t am_id,
                        uct_pack_callback_t pack_cb)

--- a/src/ucp/tag/eager.h
+++ b/src/ucp/tag/eager.h
@@ -21,6 +21,7 @@
  */
 typedef struct {
     ucp_tag_hdr_t             super;
+    uint64_t                  ep_id;
 } UCS_S_PACKED ucp_eager_hdr_t;
 
 
@@ -39,6 +40,7 @@ typedef struct {
  */
 typedef struct {
     uint64_t                  msg_id;
+    uint64_t                  ep_id;
     size_t                    offset;
 } UCS_S_PACKED ucp_eager_middle_hdr_t;
 
@@ -87,6 +89,34 @@ ucp_proto_eager_check_op_id(const ucp_proto_init_params_t *init_params,
     return (init_params->select_param->op_id == op_id) &&
            (offload_enabled ==
             ucp_ep_config_key_has_tag_lane(init_params->ep_config_key));
+}
+
+static UCS_F_ALWAYS_INLINE void
+ucp_add_uct_iov_elem(uct_iov_t *iov, void *buffer, size_t length,
+                     uct_mem_h memh, size_t *iov_cnt)
+{
+    iov[*iov_cnt].buffer = buffer;
+    iov[*iov_cnt].length = length;
+    iov[*iov_cnt].count  = 1;
+    iov[*iov_cnt].stride = 0;
+    iov[*iov_cnt].memh   = memh;
+    ++(*iov_cnt);
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_tag_send_am_short_iov(ucp_ep_h ep, const void *buffer, size_t length,
+                          ucp_tag_t tag)
+{
+    size_t iov_cnt      = 0ul;
+    ucp_eager_hdr_t hdr = { .super.tag = tag,
+                            .ep_id     = ucp_ep_remote_id(ep) };
+    uct_iov_t iov[2];
+
+    ucp_add_uct_iov_elem(iov, &hdr, sizeof(hdr), UCT_MEM_HANDLE_NULL, &iov_cnt);
+    ucp_add_uct_iov_elem(iov, (void*)buffer, length, UCT_MEM_HANDLE_NULL,
+                         &iov_cnt);
+    return uct_ep_am_short_iov(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY,
+                               iov, iov_cnt);
 }
 
 #endif

--- a/src/ucp/tag/eager_single.c
+++ b/src/ucp/tag/eager_single.c
@@ -94,6 +94,7 @@ static size_t ucp_eager_single_pack(void *dest, void *arg)
 
     ucs_assert(req->send.state.dt_iter.offset == 0);
     hdr->super.tag = req->send.msg_proto.tag;
+    hdr->ep_id     = ucp_send_request_get_ep_remote_id(req);
     packed_size    = ucp_datatype_iter_next_pack(&req->send.state.dt_iter,
                                                  req->send.ep->worker,
                                                  SIZE_MAX, &next_iter, hdr + 1);
@@ -188,7 +189,8 @@ ucp_proto_eager_zcopy_send_func(ucp_request_t *req,
                                 const uct_iov_t *iov)
 {
     ucp_eager_hdr_t hdr = {
-        .super.tag = req->send.msg_proto.tag
+        .super.tag = req->send.msg_proto.tag,
+        .ep_id     = ucp_send_request_get_ep_remote_id(req)
     };
 
     return uct_ep_am_zcopy(req->send.ep->uct_eps[spriv->super.lane],

--- a/src/ucp/tag/tag_send.c
+++ b/src/ucp/tag/tag_send.c
@@ -150,10 +150,7 @@ ucp_tag_send_inline(ucp_ep_h ep, const void *buffer, size_t length, ucp_tag_t ta
     ucs_status_t status;
 
     if (ucp_proto_is_inline(ep, &ucp_ep_config(ep)->tag.max_eager_short, length)) {
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(ucp_eager_hdr_t));
-        UCS_STATIC_ASSERT(sizeof(ucp_tag_t) == sizeof(uint64_t));
-        status = uct_ep_am_short(ucp_ep_get_am_uct_ep(ep), UCP_AM_ID_EAGER_ONLY,
-                                 tag, buffer, length);
+        status = ucp_tag_send_am_short_iov(ep, buffer, length, tag);
     } else if (ucp_proto_is_inline(ep,
                                    &ucp_ep_config(ep)->tag.offload.max_eager_short,
                                    length)) {

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -438,7 +438,8 @@ static ucs_status_t uct_rc_mlx5_iface_preinit(uct_rc_mlx5_iface_common_t *iface,
                                    UCT_IFACE_PARAM_FIELD_HW_TM_EAGER_CB |
                                    UCT_IFACE_PARAM_FIELD_HW_TM_RNDV_CB);
 
-    iface->tm.enabled = mlx5_config->tm.enable && tm_params &&
+    /* NOTE: always disable for wire compatibility */
+    iface->tm.enabled = 0 && mlx5_config->tm.enable && tm_params &&
                         (init_attr->flags & UCT_IB_TM_SUPPORTED);
     if (!iface->tm.enabled) {
         goto out_tm_disabled;


### PR DESCRIPTION
## What
 - EAGER_COMPAT_ENABLE=y adds ep_id to eager headers
 - disable HW TM for compatibility with handling in SW
