### PR TITLE
UCP/API: New user memory allocator API and an example App with memory allocator following the new API

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -5,6 +5,8 @@
 # See file LICENSE for terms.
 #
 
+CFLAGS_PEDANTIC =
+
 examplesdir = $(pkgdatadir)/examples
 dist_examples_DATA =   \
 	hello_world_util.h \


### PR DESCRIPTION
## What
- User memory allocator API
- Example App showing use of the new API

## Why ?
- Allow customer to control the memory allocation of the payloads buffers.
- Allow customer to receive "clean" buffers that contains only the payload without addition UCX meta data.

## How ?
- Define API to support passing of an external memory allocator instance that will be used by UCX for allocating new payload buffers.
