### PR TITLE
Support io_offload, memory allocator ucp & uct impl

### DIFF
--- a/src/ucp/api/ucp.h
+++ b/src/ucp/api/ucp.h
@@ -1239,6 +1239,25 @@ typedef size_t (*ucp_mem_allocator_cb_t)(void *arg, size_t num_of_buffers,
                                          void **buffers, ucp_mem_h *memh);
 
 
+typedef struct {
+    /**
+     * User memory allocator get buf function used by UCX in post receive. 
+     */
+    ucp_mem_allocator_cb_t cb;
+
+    /**
+     * User-defined argument for the allocator callback.
+     */
+    void                   *arg;
+
+    /**
+     * User memory allocator payload's buffer size.
+     * This will be the size of the active message fragment.
+     */
+    size_t                 buffer_size;
+} ucp_user_mem_allocator_t;
+
+
 /**
  * @ingroup UCP_WORKER
  * @brief Tuning parameters for the UCP worker.
@@ -1347,23 +1366,7 @@ typedef struct ucp_worker_params {
     /**
      * User defined memory allocator
      */
-    struct {
-        /**
-         * User memory allocator get buf function used by UCX in post receive. 
-         */
-        ucp_mem_allocator_cb_t cb;
-
-        /**
-         * User-defined argument for the allocator callback.
-         */
-        void                   *arg;
-
-        /**
-         * User memory allocator payload's buffer size.
-         * This will be the size of the active message fragment.
-         */
-        size_t                 buffer_size;
-    } user_allocator;
+    ucp_user_mem_allocator_t user_allocator;
 } ucp_worker_params_t;
 
 

--- a/src/ucp/core/ucp_am.c
+++ b/src/ucp/core/ucp_am.c
@@ -877,8 +877,6 @@ ucp_am_send_req(ucp_request_t *req, size_t count,
             return UCS_STATUS_PTR(status);
         }
 
-        ucs_assert(ucp_am_send_req_total_size(req) >= rndv_thresh);
-
         status = ucp_am_send_start_rndv(req, param);
         if (status != UCS_OK) {
             return UCS_STATUS_PTR(status);
@@ -1198,7 +1196,8 @@ out:
 static UCS_F_ALWAYS_INLINE ucs_status_t
 ucp_am_invoke_cb(ucp_worker_h worker, uint16_t am_id, void *user_hdr,
                  uint32_t user_hdr_length, void *data, size_t data_length,
-                 ucp_ep_h reply_ep, uint64_t recv_flags)
+                 ucp_ep_h reply_ep, uint64_t recv_flags,
+                 const uct_am_callback_params_t *uct_cb_params)
 {
     ucp_am_entry_t *am_cb = &ucs_array_elem(&worker->am.cbs, am_id);
     ucp_am_recv_param_t param;
@@ -1211,6 +1210,7 @@ ucp_am_invoke_cb(ucp_worker_h worker, uint16_t am_id, void *user_hdr,
     if (ucs_likely(am_cb->flags & UCP_AM_CB_PRIV_FLAG_NBX)) {
         param.recv_attr = recv_flags;
         param.reply_ep  = reply_ep;
+        param.payload   = uct_cb_params->payload;
 
         return am_cb->cb(am_cb->context, user_hdr, user_hdr_length, data,
                          data_length, &param);
@@ -1223,8 +1223,8 @@ ucp_am_invoke_cb(ucp_worker_h worker, uint16_t am_id, void *user_hdr,
         return UCS_OK;
     }
 
-    flags = (recv_flags & UCP_AM_RECV_ATTR_FLAG_DATA) ?
-            UCP_CB_PARAM_FLAG_DATA : 0;
+    flags = (recv_flags & UCP_AM_RECV_ATTR_FLAG_DATA) ? UCP_CB_PARAM_FLAG_DATA :
+                                                        0;
 
     return am_cb->cb_old(am_cb->context, data, data_length, reply_ep, flags);
 }
@@ -1232,7 +1232,7 @@ ucp_am_invoke_cb(ucp_worker_h worker, uint16_t am_id, void *user_hdr,
 static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_handler_common(
         ucp_worker_h worker, ucp_am_hdr_t *am_hdr, size_t total_length,
         ucp_ep_h reply_ep, unsigned am_flags, uint64_t recv_flags,
-        const char *name)
+        const char *name, const uct_am_callback_params_t *params)
 {
     ucp_recv_desc_t *desc    = NULL;
     uint16_t am_id           = am_hdr->am_id;
@@ -1241,7 +1241,7 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_handler_common(
     void *data               = am_hdr + 1;
     size_t data_length       = total_length -
                                (sizeof(*am_hdr) + am_hdr->header_length);
-    void *user_hdr           = UCS_PTR_BYTE_OFFSET(data, data_length);
+    void *user_hdr = UCS_PTR_BYTE_OFFSET(params->payload, data_length);
     ucs_status_t desc_status = UCS_OK;
     ucs_status_t status;
 
@@ -1277,12 +1277,13 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_handler_common(
                       worker, am_id);
             return UCS_OK;
         }
-        data        = desc + 1;
+        desc->length  = data_length;
         recv_flags |= UCP_AM_RECV_ATTR_FLAG_DATA;
     }
 
-    status = ucp_am_invoke_cb(worker, am_id, user_hdr, user_hdr_size, data,
-                              data_length, reply_ep, recv_flags);
+    status = ucp_am_invoke_cb(worker, am_id, user_hdr, user_hdr_size,
+                              desc + 1, data_length, reply_ep,
+                              recv_flags, params);
     if (desc == NULL) {
         if (ucs_unlikely(status == UCS_INPROGRESS)) {
             ucs_error("can't hold data, FLAG_DATA flag is not set");
@@ -1306,14 +1307,16 @@ static UCS_F_ALWAYS_INLINE ucs_status_t ucp_am_handler_common(
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_am_handler_reply,
-                 (am_arg, am_data, am_length, am_flags, params), void *am_arg,
-                 void *am_data, size_t am_length, unsigned am_flags,
-                 uct_am_callback_params_t *params)
+                 (am_arg, am_data, am_length, am_flags, params),
+                 void *am_arg, void *am_data, size_t am_length,
+                 unsigned am_flags, uct_am_callback_params_t *params)
 {
     ucp_am_hdr_t *hdr       = (ucp_am_hdr_t*)am_data;
     ucp_worker_h worker     = (ucp_worker_h)am_arg;
-    ucp_am_reply_ftr_t *ftr = UCS_PTR_BYTE_OFFSET(am_data,
-                                                  am_length - sizeof(*ftr));
+    size_t reply_ftr_offset = am_length - sizeof(ucp_am_reply_ftr_t) -
+                              sizeof(ucp_am_hdr_t);
+    ucp_am_reply_ftr_t *ftr = UCS_PTR_BYTE_OFFSET(params->payload,
+                                                  reply_ftr_offset);
     ucp_ep_h reply_ep;
 
     UCP_WORKER_GET_VALID_EP_BY_ID(&reply_ep, worker, ftr->ep_id, return UCS_OK,
@@ -1321,19 +1324,19 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_handler_reply,
 
     return ucp_am_handler_common(worker, hdr, am_length - sizeof(ftr), reply_ep,
                                  am_flags, UCP_AM_RECV_ATTR_FIELD_REPLY_EP,
-                                 "am_handler_reply");
+                                 "am_handler_reply", params);
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_am_handler,
-                 (am_arg, am_data, am_length, am_flags, params), void *am_arg,
-                 void *am_data, size_t am_length, unsigned am_flags,
-                 uct_am_callback_params_t *params)
+                 (am_arg, am_data, am_length, am_flags, params),
+                 void *am_arg, void *am_data, size_t am_length,
+                 unsigned am_flags, uct_am_callback_params_t *params)
 {
     ucp_worker_h worker = am_arg;
     ucp_am_hdr_t *hdr   = am_data;
 
     return ucp_am_handler_common(worker, hdr, am_length, NULL, am_flags, 0ul,
-                                 "am_handler");
+                                 "am_handler", params);
 }
 
 static UCS_F_ALWAYS_INLINE ucp_recv_desc_t *
@@ -1432,7 +1435,7 @@ ucp_am_handle_unfinished(ucp_worker_h worker, ucp_recv_desc_t *first_rdesc,
     status                           = ucp_am_invoke_cb(worker, am_id, user_hdr,
                                                         user_hdr_length,
                                                         payload, total_size,
-                                                        reply_ep, recv_flags);
+                                                        reply_ep, recv_flags, NULL);
     if (!ucp_am_rdesc_in_progress(first_rdesc, status)) {
         /* user does not need to hold this data */
         ucp_am_release_long_desc(first_rdesc);
@@ -1444,9 +1447,9 @@ ucp_am_handle_unfinished(ucp_worker_h worker, ucp_recv_desc_t *first_rdesc,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
-                 (am_arg, am_data, am_length, am_flags, params), void *am_arg,
-                 void *am_data, size_t am_length, unsigned am_flags,
-                 uct_am_callback_params_t *params)
+                 (am_arg, am_data, am_length, am_flags, params),
+                 void *am_arg, void *am_data, size_t am_length,
+                 unsigned am_flags, uct_am_callback_params_t *params)
 {
     ucp_worker_h worker    = am_arg;
     ucp_am_hdr_t *hdr      = am_data;
@@ -1478,7 +1481,7 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
         return ucp_am_handler_common(worker, hdr,
                                      am_length - sizeof(*first_ftr), ep,
                                      am_flags, recv_flags,
-                                     "am_long_first_handler");
+                                     "am_long_first_handler", params);
     }
 
     /* This is the first fragment, other fragments (if arrived) should be on
@@ -1561,9 +1564,9 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_first_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_middle_handler,
-                 (am_arg, am_data, am_length, am_flags, params), void *am_arg,
-                 void *am_data, size_t am_length, unsigned am_flags,
-                 uct_am_callback_params_t *params)
+                 (am_arg, am_data, am_length, am_flags, params),
+                 void *am_arg, void *am_data, size_t am_length,
+                 unsigned am_flags, uct_am_callback_params_t *params)
 {
     ucp_worker_h worker        = am_arg;
     ucp_am_mid_hdr_t *mid_hdr  = am_data;
@@ -1610,18 +1613,18 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_am_long_middle_handler,
     return status;
 }
 
-ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
-                                     unsigned tl_flags)
+void ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
+                             unsigned tl_flags)
 {
-    ucp_rndv_rts_hdr_t *rts = data;
+    ucp_recv_desc_t *desc   = data;
+    ucp_rndv_rts_hdr_t *rts = (ucp_rndv_rts_hdr_t*)(desc + 1);
     ucp_worker_h worker     = arg;
     ucp_am_hdr_t *am        = ucp_am_hdr_from_rts(rts);
     uint16_t am_id          = am->am_id;
-    ucp_recv_desc_t *desc   = NULL;
     ucp_am_entry_t *am_cb   = &ucs_array_elem(&worker->am.cbs, am_id);
     ucp_ep_h ep;
     ucp_am_recv_param_t param;
-    ucs_status_t status, desc_status;
+    ucs_status_t status;
     void *hdr;
 
     if (ENABLE_PARAMS_CHECK && !(am_cb->flags & UCP_AM_CB_PRIV_FLAG_NBX)) {
@@ -1649,17 +1652,6 @@ ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
         hdr = NULL;
     }
 
-    desc_status = ucp_recv_desc_init(worker, data, length, 0, tl_flags, 0,
-                                     UCP_RECV_DESC_FLAG_RNDV |
-                                     UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS, 0, 1,
-                                     "am_rndv_process_rts", &desc);
-    if (ucs_unlikely(UCS_STATUS_IS_ERR(desc_status))) {
-        ucs_error("worker %p could not allocate descriptor for active"
-                  " message RTS on callback %u", worker, am_id);
-        status = UCS_ERR_NO_MEMORY;
-        goto out_send_ats;
-    }
-
     param.recv_attr = UCP_AM_RECV_ATTR_FLAG_RNDV |
                       ucp_am_hdr_reply_ep(worker, am->flags, ep,
                                           &param.reply_ep);
@@ -1672,7 +1664,7 @@ ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
                     ucs_status_string(status));
 
         desc->flags &= ~UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS;
-        return desc_status;
+        return;
     } else if (desc->flags & UCP_RECV_DESC_FLAG_RECV_STARTED) {
         /* User initiated rendezvous receive in the callback and it is
          * already completed. No need to save the descriptor for further use
@@ -1689,6 +1681,7 @@ out_send_ats:
     /* Some error occurred or user does not need this data. Send ATS back to the
      * sender to complete its send request. */
     ucp_am_rndv_send_ats(worker, rts, status);
+    ucp_recv_desc_release(desc);
 
 out:
     if (desc != NULL) {
@@ -1705,8 +1698,6 @@ out:
             ucp_recv_desc_release(desc);
         }
     }
-
-    return UCS_OK;
 }
 
 UCP_DEFINE_AM(UCP_FEATURE_AM, UCP_AM_ID_AM_SINGLE,

--- a/src/ucp/core/ucp_am.h
+++ b/src/ucp/core/ucp_am.h
@@ -131,7 +131,7 @@ size_t ucp_am_max_header_size(ucp_worker_h worker);
 
 ucs_status_t ucp_proto_progress_am_rndv_rts(uct_pending_req_t *self);
 
-ucs_status_t ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
-                                     unsigned tl_flags);
+void ucp_am_rndv_process_rts(void *arg, void *data, size_t length,
+                             unsigned tl_flags);
 
 #endif

--- a/src/ucp/core/ucp_context.c
+++ b/src/ucp/core/ucp_context.c
@@ -184,7 +184,7 @@ static ucs_config_field_t ucp_context_config_table[] = {
    "multiple rails. Must be greater than 0.",
    ucs_offsetof(ucp_context_config_t, min_rndv_chunk_size), UCS_CONFIG_TYPE_MEMUNITS},
 
-  {"RNDV_SCHEME", "auto",
+  {"RNDV_SCHEME", "get_zcopy",
    "Communication scheme in RNDV protocol.\n"
    " get_zcopy - use get_zcopy scheme in RNDV protocol.\n"
    " put_zcopy - use put_zcopy scheme in RNDV protocol.\n"

--- a/src/ucp/core/ucp_request.c
+++ b/src/ucp/core/ucp_request.c
@@ -593,7 +593,6 @@ ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
                                     const ucp_request_param_t *param)
 {
     ucs_status_t status;
-    int          multi;
 
     req->status = UCS_INPROGRESS;
 
@@ -602,20 +601,20 @@ ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
         req->send.uct.func = proto->contig_short;
         UCS_PROFILE_REQUEST_EVENT(req, "start_contig_short", req->send.length);
         return UCS_OK;
-    } else if (length < zcopy_thresh) {
+        // disable bcopy multi fragment proto
+    } else if ((length < zcopy_thresh) &&
+               (length <= (msg_config->max_bcopy - proto->only_hdr_size))) {
         /* bcopy */
         ucp_request_send_state_reset(req, NULL, UCP_REQUEST_SEND_PROTO_BCOPY_AM);
         ucs_assert(msg_config->max_bcopy >= proto->only_hdr_size);
-        if (length <= (msg_config->max_bcopy - proto->only_hdr_size)) {
-            req->send.uct.func = proto->bcopy_single;
-            UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_single", req->send.length);
-        } else {
-            ucp_request_init_multi_proto(req, proto->bcopy_multi,
-                                         "start_bcopy_multi");
-        }
+        req->send.uct.func = proto->bcopy_single;
+        UCS_PROFILE_REQUEST_EVENT(req, "start_bcopy_single", req->send.length);
 
         return UCS_OK;
-    } else if (length < zcopy_max) {
+        // disable zcopy multi fragment proto
+    } else if ((length < zcopy_max) &&
+               ucs_likely(length <
+                          msg_config->max_zcopy - proto->only_hdr_size)) {
         /* zcopy */
         ucp_request_send_state_reset(req, proto->zcopy_completion,
                                      UCP_REQUEST_SEND_PROTO_ZCOPY_AM);
@@ -630,26 +629,8 @@ ucs_status_t ucp_request_send_start(ucp_request_t *req, ssize_t max_short,
             return status;
         }
 
-        if (ucs_unlikely(length > msg_config->max_zcopy - proto->only_hdr_size)) {
-            multi = 1;
-        } else if (ucs_unlikely(UCP_DT_IS_IOV(req->send.datatype))) {
-            if (dt_count <= (msg_config->max_iov - priv_iov_count)) {
-                multi = 0;
-            } else {
-                multi = ucp_dt_iov_count_nonempty(req->send.buffer, dt_count) >
-                        (msg_config->max_iov - priv_iov_count);
-            }
-        } else {
-            multi = 0;
-        }
-
-        if (multi) {
-            ucp_request_init_multi_proto(req, proto->zcopy_multi,
-                                         "start_zcopy_multi");
-        } else {
-            req->send.uct.func = proto->zcopy_single;
-            UCS_PROFILE_REQUEST_EVENT(req, "start_zcopy_single", req->send.length);
-        }
+        req->send.uct.func = proto->zcopy_single;
+        UCS_PROFILE_REQUEST_EVENT(req, "start_zcopy_single", req->send.length);
 
         return UCS_OK;
     }

--- a/src/ucp/core/ucp_request.inl
+++ b/src/ucp/core/ucp_request.inl
@@ -796,16 +796,17 @@ ucp_recv_desc_set_name(ucp_recv_desc_t *rdesc, const char *name)
 #endif
 }
 
-static UCS_F_ALWAYS_INLINE ucs_status_t
-ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
-                   int data_offset, unsigned am_flags, uint16_t hdr_len,
-                   uint16_t rdesc_flags, int priv_length, size_t alignment,
-                   const char *name, ucp_recv_desc_t **rdesc_p)
+static UCS_F_ALWAYS_INLINE ucs_status_t ucp_recv_desc_init_payload(
+        ucp_worker_h worker, void *data, size_t length, int data_offset,
+        unsigned am_flags, uint16_t hdr_len, uint16_t rdesc_flags,
+        int priv_length, size_t alignment, const void *payload,
+        const char *name, ucp_recv_desc_t **rdesc_p)
 {
     ucp_recv_desc_t *rdesc;
     void *data_hdr;
     ucs_status_t status;
     size_t padding;
+    void *dest;
 
     if (ucs_unlikely(am_flags & UCT_CB_PARAM_FLAG_DESC)) {
         /* slowpath */
@@ -832,7 +833,12 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
          * needed for releasing UCT descriptor. */
         rdesc->flags = rdesc_flags;
         status       = UCS_OK;
-        memcpy(UCS_PTR_BYTE_OFFSET(rdesc + 1, data_offset), data, length);
+        dest = UCS_PTR_BYTE_OFFSET(rdesc + 1, data_offset);
+        memcpy(dest, data, sizeof(ucp_am_hdr_t));
+        if (length > sizeof(ucp_am_hdr_t)) {
+            dest = UCS_PTR_BYTE_OFFSET(dest, sizeof(ucp_am_hdr_t));
+            memcpy(dest, payload, length - sizeof(ucp_am_hdr_t));
+        }
     }
 
     ucp_recv_desc_set_name(rdesc, name);
@@ -840,6 +846,18 @@ ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
     rdesc->payload_offset = hdr_len;
     *rdesc_p              = rdesc;
     return status;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+ucp_recv_desc_init(ucp_worker_h worker, void *data, size_t length,
+                   int data_offset, unsigned am_flags, uint16_t hdr_len,
+                   uint16_t rdesc_flags, int priv_length, size_t alignment,
+                   const char *name, ucp_recv_desc_t **rdesc_p)
+{
+    return ucp_recv_desc_init_payload(
+            worker, data, length, data_offset, am_flags, hdr_len, rdesc_flags,
+            priv_length, alignment,
+            UCS_PTR_BYTE_OFFSET(data, sizeof(ucp_am_hdr_t)), name, rdesc_p);
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/ucp/core/ucp_worker.h
+++ b/src/ucp/core/ucp_worker.h
@@ -294,6 +294,8 @@ typedef struct ucp_worker {
                                                              one for each resource */
     unsigned                         num_ifaces;          /* Number of elements in ifaces array  */
     unsigned                         num_active_ifaces;   /* Number of activated ifaces  */
+
+    ucp_user_mem_allocator_t         user_mem_allocator;  /* User defined memory allocator */
     ucp_tl_bitmap_t                  scalable_tl_bitmap;  /* Map of scalable tl resources */
     ucp_worker_cm_t                  *cms;                /* Array of CMs, one for each component */
     ucs_mpool_set_t                  am_mps;              /* Memory pool set for AM receives */

--- a/src/ucp/proto/proto_am.inl
+++ b/src/ucp/proto/proto_am.inl
@@ -617,4 +617,14 @@ ucp_am_pack_user_header(void *buffer, ucp_request_t *req)
                 req->send.msg_proto.am.header.length);
 }
 
+#define UCP_AM_CONCAT_MSG_HDR(_hdr, _payload, _length, _msg_hdr) \
+{ \
+    void *_buff = ucs_alloca(_length); \
+    \
+    memcpy(_buff, (_hdr), sizeof(ucp_am_hdr_t)); \
+    memcpy(UCS_PTR_BYTE_OFFSET(_buff, sizeof(ucp_am_hdr_t)), \
+            (_payload), (_length) - sizeof(ucp_am_hdr_t)); \
+    _msg_hdr = _buff; \
+}
+
 #endif

--- a/src/ucp/rndv/proto_rndv.c
+++ b/src/ucp/rndv/proto_rndv.c
@@ -763,16 +763,17 @@ static void ucp_proto_rndv_send_complete_one(void *request, ucs_status_t status,
     ucp_proto_request_zcopy_complete(req, status);
 }
 
-ucs_status_t
-ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags)
+ucs_status_t ucp_proto_rndv_handle_rtr(void *arg, void *data, void *payload,
+                                       size_t length, unsigned flags)
 {
     ucp_worker_h worker           = arg;
-    const ucp_rndv_rtr_hdr_t *rtr = data;
     ucp_request_t *req, *freq;
     ucs_status_t status;
     uint32_t op_flags;
     uint8_t sg_count;
+    ucp_rndv_rtr_hdr_t *rtr;
 
+    UCP_AM_CONCAT_MSG_HDR(data, payload, length, rtr);
     UCP_SEND_REQUEST_GET_BY_ID(&req, worker, rtr->sreq_id, 0, return UCS_OK,
                                "RTR %p", rtr);
 

--- a/src/ucp/rndv/proto_rndv.h
+++ b/src/ucp/rndv/proto_rndv.h
@@ -142,16 +142,16 @@ void ucp_proto_rndv_receive_start(ucp_worker_h worker, ucp_request_t *recv_req,
                                   const void *rkey_buffer, size_t rkey_length);
 
 
-ucs_status_t
-ucp_proto_rndv_handle_rtr(void *arg, void *data, size_t length, unsigned flags);
+ucs_status_t ucp_proto_rndv_handle_rtr(void *arg, void *data, void *payload,
+                                       size_t length, unsigned flags);
 
 
-ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,
-                                           unsigned flags);
+ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, void *payload,
+                                           size_t length, unsigned flags);
 
 
-ucs_status_t ucp_proto_rndv_handle_data(void *arg, void *data, size_t length,
-                                        unsigned flags);
+ucs_status_t ucp_proto_rndv_handle_data(void *arg, void *data, void *payload,
+                                        size_t length, unsigned flags);
 
 
 /* Initialize req->send.multi_lane_idx according to req->rndv.offset */

--- a/src/ucp/rndv/rndv.c
+++ b/src/ucp/rndv/rndv.c
@@ -1793,30 +1793,46 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rts_handler,
                  size_t length, unsigned tl_flags,
                  uct_am_callback_params_t *params)
 {
-    ucp_worker_h worker         = arg;
-    ucp_rndv_rts_hdr_t *rts_hdr = data;
+    const unsigned rdesc_flags = UCP_RECV_DESC_FLAG_RNDV |
+                                 UCP_RECV_DESC_FLAG_AM_CB_INPROGRESS;
+    ucp_worker_h worker        = arg;
+    ucp_rndv_rts_hdr_t *rts_hdr;
+    ucp_recv_desc_t *rdesc;
+    ucs_status_t status;
 
+    status = ucp_recv_desc_init_payload(worker, data, length, 0, 0, 0,
+                                        rdesc_flags, 0, 1, params->payload,
+                                        "am_rndv_process_rts", &rdesc);
+    if (ucs_unlikely(status != UCS_OK)) {
+        return status;
+    }
+
+    rts_hdr = (ucp_rndv_rts_hdr_t*)(rdesc + 1);
     if (ucp_rndv_rts_is_am(rts_hdr)) {
-        return ucp_am_rndv_process_rts(arg, data, length, tl_flags);
+        ucp_am_rndv_process_rts(arg, rdesc, length, tl_flags);
     } else {
         ucs_assert(ucp_rndv_rts_is_tag(rts_hdr));
-        return ucp_tag_rndv_process_rts(worker, rts_hdr, length, tl_flags);
+        ucp_tag_rndv_process_rts(worker, rts_hdr, length, tl_flags);
+        ucp_recv_desc_release(rdesc);
     }
+
+    return UCS_OK;
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_ats_handler,
-                 (arg, data, length, flags, params), void *arg, void *data,
-                 size_t length, unsigned flags,
+                 (arg, data, length, flags, params),
+                 void *arg, void *data, size_t length, unsigned flags,
                  uct_am_callback_params_t *params)
 {
-    ucp_worker_h worker      = arg;
-    ucp_reply_hdr_t *rep_hdr = data;
+    ucp_worker_h worker = arg;
+    ucp_reply_hdr_t *rep_hdr;
     ucp_request_t *sreq;
 
     if (worker->context->config.ext.proto_enable) {
         return ucp_proto_rndv_ats_handler(arg, data, length, flags);
     }
 
+    UCP_AM_CONCAT_MSG_HDR(data, params->payload, length, rep_hdr);
     UCP_SEND_REQUEST_GET_BY_ID(&sreq, worker, rep_hdr->req_id, 1, return UCS_OK,
                                "RNDV ATS %p", rep_hdr);
 
@@ -2265,19 +2281,21 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_progress_rma_get_zcopy, (self),
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
-                 (arg, data, length, flags, params), void *arg, void *data,
-                 size_t length, unsigned flags,
+                 (arg, data, length, flags, params),
+                 void *arg, void *data, size_t length, unsigned flags,
                  uct_am_callback_params_t *params)
 {
-    ucp_worker_h worker      = arg;
-    ucp_reply_hdr_t *rep_hdr = data;
+    ucp_worker_h worker = arg;
     ucp_request_t *rtr_sreq, *req;
     ucp_mem_desc_t *mdesc;
+    ucp_reply_hdr_t *rep_hdr;
 
     if (worker->context->config.ext.proto_enable) {
-        return ucp_proto_rndv_rtr_handle_atp(arg, data, length, flags);
+        return ucp_proto_rndv_rtr_handle_atp(arg, data, params->payload, length,
+                                             flags);
     }
 
+    UCP_AM_CONCAT_MSG_HDR(data, params->payload, length, rep_hdr);
     UCP_SEND_REQUEST_GET_BY_ID(&rtr_sreq, worker, rep_hdr->req_id, 1,
                                return UCS_OK, "RNDV ATP %p", rep_hdr);
 
@@ -2302,13 +2320,12 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_atp_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
-                 (arg, data, length, flags, params), void *arg, void *data,
-                 size_t length, unsigned flags,
+                 (arg, data, length, flags, params),
+                 void *arg, void *data, size_t length, unsigned flags,
                  uct_am_callback_params_t *params)
 {
-    ucp_worker_h worker              = arg;
-    ucp_context_h context            = worker->context;
-    ucp_rndv_rtr_hdr_t *rndv_rtr_hdr = data;
+    ucp_worker_h worker   = arg;
+    ucp_context_h context = worker->context;
     ucp_ep_rndv_zcopy_config_t *put_zcopy;
     ucp_request_t *sreq;
     ucp_ep_h ep;
@@ -2317,11 +2334,14 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_rtr_handler,
     int is_put_pipeline;
     int is_put_supported;
     uct_rkey_t uct_rkey;
+    ucp_rndv_rtr_hdr_t *rndv_rtr_hdr;
 
     if (context->config.ext.proto_enable) {
-        return ucp_proto_rndv_handle_rtr(arg, data, length, flags);
+        return ucp_proto_rndv_handle_rtr(arg, data, params->payload, length,
+                                         flags);
     }
 
+    UCP_AM_CONCAT_MSG_HDR(data, params->payload, length, rndv_rtr_hdr);
     UCP_SEND_REQUEST_GET_BY_ID(&sreq, arg, rndv_rtr_hdr->sreq_id, 0,
                                return UCS_OK, "RNDV RTR %p", rndv_rtr_hdr);
     ep        = sreq->send.ep;
@@ -2429,20 +2449,22 @@ out_send:
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_rndv_data_handler,
-                 (arg, data, length, flags, params), void *arg, void *data,
-                 size_t length, unsigned flags,
+                 (arg, data, length, flags, params),
+                 void *arg, void *data, size_t length, unsigned flags,
                  uct_am_callback_params_t *params)
 {
-    ucp_worker_h worker                   = arg;
-    ucp_request_data_hdr_t *rndv_data_hdr = data;
+    ucp_worker_h worker = arg;
     ucp_request_t *rreq, *rndv_req;
     size_t recv_len;
     ucs_status_t status;
+    ucp_request_data_hdr_t *rndv_data_hdr;
 
     if (worker->context->config.ext.proto_enable) {
-        return ucp_proto_rndv_handle_data(arg, data, length, flags);
+        return ucp_proto_rndv_handle_data(arg, data, params->payload, length,
+                                          flags);
     }
 
+    UCP_AM_CONCAT_MSG_HDR(data, params->payload, length, rndv_data_hdr);
     UCP_SEND_REQUEST_GET_BY_ID(&rndv_req, worker, rndv_data_hdr->req_id, 0,
                                return UCS_OK, "RNDV data %p", rndv_data_hdr);
 

--- a/src/ucp/rndv/rndv_rtr.c
+++ b/src/ucp/rndv/rndv_rtr.c
@@ -395,14 +395,15 @@ ucp_proto_t ucp_rndv_rtr_mtype_proto = {
     .abort    = (ucp_request_abort_func_t)ucs_empty_function_do_assert_void
 };
 
-ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,
-                                           unsigned flags)
+ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, void *payload,
+                                           size_t length, unsigned flags)
 {
     ucp_worker_h worker     = arg;
-    ucp_rndv_ack_hdr_t *atp = data;
     const ucp_proto_rndv_rtr_priv_t *rpriv;
     ucp_request_t *req;
+    ucp_rndv_ack_hdr_t *atp;
 
+    UCP_AM_CONCAT_MSG_HDR(data, payload, length, atp);
     UCP_SEND_REQUEST_GET_BY_ID(&req, worker, atp->super.req_id, 0,
                                return UCS_OK, "ATP %p", atp);
 
@@ -417,22 +418,25 @@ ucs_status_t ucp_proto_rndv_rtr_handle_atp(void *arg, void *data, size_t length,
     return UCS_OK;
 }
 
-ucs_status_t
-ucp_proto_rndv_handle_data(void *arg, void *data, size_t length, unsigned flags)
+ucs_status_t ucp_proto_rndv_handle_data(void *arg, void *data, void *payload,
+                                        size_t length, unsigned flags)
 {
-    ucp_worker_h worker                   = arg;
-    ucp_request_data_hdr_t *rndv_data_hdr = data;
-    size_t recv_len                       = length - sizeof(*rndv_data_hdr);
+    ucp_worker_h worker = arg;
+    size_t recv_len     = length - sizeof(ucp_request_data_hdr_t);
+    size_t data_offset = sizeof(ucp_request_data_hdr_t) - sizeof(ucp_am_hdr_t);
     const ucp_proto_rndv_rtr_priv_t *rpriv;
     ucs_status_t status;
     ucp_request_t *req;
+    ucp_request_data_hdr_t *rndv_data_hdr;
 
+    UCP_AM_CONCAT_MSG_HDR(data, payload, length, rndv_data_hdr);
     UCP_SEND_REQUEST_GET_BY_ID(&req, worker, rndv_data_hdr->req_id, 0,
                                return UCS_OK, "RNDV_DATA %p", rndv_data_hdr);
 
     status = ucp_datatype_iter_unpack(&req->send.state.dt_iter, worker,
                                       recv_len, rndv_data_hdr->offset,
-                                      rndv_data_hdr + 1);
+                                      UCS_PTR_BYTE_OFFSET(payload,
+                                                          data_offset));
     if (status != UCS_OK) {
         ucp_proto_request_abort(req, status);
         return UCS_OK;

--- a/src/ucp/tag/eager_rcv.c
+++ b/src/ucp/tag/eager_rcv.c
@@ -135,8 +135,8 @@ ucp_eager_tagged_handler(void *arg, void *data, size_t length, unsigned am_flags
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_only_handler,
-                 (arg, data, length, am_flags, params), void *arg, void *data,
-                 size_t length, unsigned am_flags,
+                 (arg, data, length, am_flags, params),
+                 void *arg, void *data, size_t length, unsigned am_flags,
                  uct_am_callback_params_t *params)
 {
     return ucp_eager_tagged_handler(arg, data, length, am_flags,
@@ -147,8 +147,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_only_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_first_handler,
-                 (arg, data, length, am_flags, params), void *arg, void *data,
-                 size_t length, unsigned am_flags,
+                 (arg, data, length, am_flags, params),
+                 void *arg, void *data, size_t length, unsigned am_flags,
                  uct_am_callback_params_t *params)
 {
     return ucp_eager_tagged_handler(arg, data, length, am_flags,
@@ -159,8 +159,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_first_handler,
 
 /* Handler for middle fragments of SW eager messages */
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_middle_handler,
-                 (arg, data, length, am_flags, params), void *arg, void *data,
-                 size_t length, unsigned am_flags,
+                 (arg, data, length, am_flags, params),
+                 void *arg, void *data, size_t length, unsigned am_flags,
                  uct_am_callback_params_t *params)
 {
     ucp_worker_h worker         = arg;
@@ -226,8 +226,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_middle_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_only_handler,
-                 (arg, data, length, am_flags, params), void *arg, void *data,
-                 size_t length, unsigned am_flags,
+                 (arg, data, length, am_flags, params),
+                 void *arg, void *data, size_t length, unsigned am_flags,
                  uct_am_callback_params_t *params)
 {
     return ucp_eager_tagged_handler(arg, data, length, am_flags,
@@ -239,8 +239,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_only_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_first_handler,
-                 (arg, data, length, am_flags, params), void *arg, void *data,
-                 size_t length, unsigned am_flags,
+                 (arg, data, length, am_flags, params),
+                 void *arg, void *data, size_t length, unsigned am_flags,
                  uct_am_callback_params_t *params)
 {
     return ucp_eager_tagged_handler(arg, data, length, am_flags,
@@ -251,8 +251,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_first_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_offload_sync_ack_handler,
-                 (arg, data, length, am_flags, params), void *arg, void *data,
-                 size_t length, unsigned am_flags,
+                 (arg, data, length, am_flags, params),
+                 void *arg, void *data, size_t length, unsigned am_flags,
                  uct_am_callback_params_t *params)
 {
     ucp_offload_ssend_hdr_t *rep_hdr = data;
@@ -279,8 +279,8 @@ UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_offload_sync_ack_handler,
 }
 
 UCS_PROFILE_FUNC(ucs_status_t, ucp_eager_sync_ack_handler,
-                 (arg, data, length, am_flags, params), void *arg, void *data,
-                 size_t length, unsigned am_flags,
+                 (arg, data, length, am_flags, params),
+                 void *arg, void *data, size_t length, unsigned am_flags,
                  uct_am_callback_params_t *params)
 {
     ucp_worker_h    worker   = arg;

--- a/src/ucp/wireup/wireup.c
+++ b/src/ucp/wireup/wireup.c
@@ -794,18 +794,19 @@ void ucp_wireup_process_ack(ucp_worker_h worker, ucp_ep_h ep,
     ucp_wireup_remote_connected(ep);
 }
 
-static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data, size_t length,
-                                           unsigned flags,
+static ucs_status_t ucp_wireup_msg_handler(void *arg, void *data,
+                                           size_t length, unsigned flags,
                                            uct_am_callback_params_t *params)
 {
-    ucp_worker_h worker   = arg;
-    ucp_wireup_msg_t *msg = data;
-    ucp_ep_h ep           = NULL;
+    ucp_worker_h worker = arg;
+    ucp_ep_h ep         = NULL;
     ucp_unpacked_address_t remote_address;
+    ucp_wireup_msg_t *msg;
     ucs_status_t status;
 
     UCS_ASYNC_BLOCK(&worker->async);
 
+    UCP_AM_CONCAT_MSG_HDR(data, params->payload, length, msg);
     if (msg->dst_ep_id != UCS_PTR_MAP_KEY_INVALID) {
         UCP_WORKER_GET_EP_BY_ID(
                 &ep, worker, msg->dst_ep_id,

--- a/src/uct/api/uct.h
+++ b/src/uct/api/uct.h
@@ -673,7 +673,16 @@ enum uct_iface_params_field {
     UCT_IFACE_PARAM_FIELD_AM_ALIGN_OFFSET    = UCS_BIT(17),
 
     /** Enables @ref uct_iface_params_t::features */
-    UCT_IFACE_PARAM_FIELD_FEATURES           = UCS_BIT(18)
+    UCT_IFACE_PARAM_FIELD_FEATURES           = UCS_BIT(18),
+
+    /** Enables @ref uct_iface_params_t::rx_header_length */
+    UCT_IFACE_PARAM_FIELD_RX_HEADER_LENGTH   = UCS_BIT(19),
+
+    /** Enables @ref uct_iface_params_t::rx_payload_length */
+    UCT_IFACE_PARAM_FIELD_RX_PAYLOAD_LENGTH  = UCS_BIT(20),
+
+    /** Enables @ref uct_iface_params_t::rx_allocator */
+    UCT_IFACE_PARAM_FIELD_USER_ALLOCATOR     = UCS_BIT(21)
 };
 
 /**
@@ -1073,6 +1082,23 @@ struct uct_iface_attr {
 };
 
 
+/*
+ * @ingroup UCT_RESOURCE
+ * @RX buffers allocator obj
+ *
+ *  This structure holds an memory allocator context and it's used for
+ *  allocating rx buffers when performing post receive.
+ *
+ */
+struct uct_rx_allocator {
+    /* User allocator get cb */
+    uct_user_allocator_get_buf_cb_t cb;
+
+    /* User-defined argument for the allocator callback */
+    void                            *arg;
+};
+
+
 /**
  * @ingroup UCT_RESOURCE
  * @brief Parameters used for interface creation.
@@ -1184,6 +1210,18 @@ struct uct_iface_params {
      * initialization.
      */
     uint64_t                                     features;
+
+    /* RX allocator header length */
+    size_t                                       rx_header_length;
+
+    /**
+     * Size of the payload receive buffer used by
+     * this interface for incoming active messages.
+     */
+    size_t                                       rx_payload_length;
+
+    /* RX buffers allocator passed by the client to be used in post/recv */
+    uct_rx_allocator_t                           rx_allocator;
 };
 
 

--- a/src/uct/api/uct_def.h
+++ b/src/uct/api/uct_def.h
@@ -27,6 +27,12 @@
 #define UCT_INVALID_RKEY           ((uintptr_t)(-1))
 #define UCT_INLINE_API             static UCS_F_ALWAYS_INLINE
 
+/**
+ * UCT RX allocator cache size.
+ * This is the maximal capacity of buffers array.
+ * */
+#define UCT_ALLOCATOR_MAX_RX_BUFFS 64
+
 
 /**
  * @ingroup UCT_AM
@@ -108,6 +114,7 @@ typedef struct uct_tag_context       uct_tag_context_t;
 typedef uint64_t                     uct_tag_t;  /* tag type - 64 bit */
 typedef int                          uct_worker_cb_id_t;
 typedef void*                        uct_conn_request_h;
+typedef struct uct_rx_allocator      uct_rx_allocator_t;
 
 /**
  * @}
@@ -542,8 +549,8 @@ typedef struct uct_am_callback_params {
  *                          released later by their owner.
  *
  */
-typedef ucs_status_t (*uct_am_callback_t)(void *arg, void *msg_hdr, size_t length,
-                                          unsigned flags,
+typedef ucs_status_t (*uct_am_callback_t)(void *arg, void *msg_hdr,
+                                          size_t length, unsigned flags,
                                           uct_am_callback_params_t *params);
 
 
@@ -936,5 +943,24 @@ typedef ucs_status_t (*uct_tag_unexp_rndv_cb_t)(void *arg, unsigned flags,
  */
 typedef void (*uct_async_event_cb_t)(void *arg, unsigned flags);
 
+
+/**
+ * Get buffer and uct memory handler from user allocator.
+ *
+ * @param [in]  arg            User-defined argument for the allocator callback.
+ * @param [in]  num_of_buffers Number of buffers required.
+ *
+ * @param [out] memh           Memory handle associated with the returned buffers.
+ *                             @note It's assumed that all buffers returned by
+ *                             this callback share the same memory handle
+ * @param [out] buffers        Returned buffers.
+ *
+ * @return                     Number of allocated buffers if successful.
+ *                             In case of an error return 0.
+ */
+typedef size_t (*uct_user_allocator_get_buf_cb_t)(void *arg,
+                                                  size_t num_of_buffers,
+                                                  uct_mem_h *memh,
+                                                  void **buffers);
 
 #endif

--- a/src/uct/ib/base/ib_iface.h
+++ b/src/uct/ib/base/ib_iface.h
@@ -52,6 +52,16 @@ enum {
 
 
 /**
+ * IB RX segments scatter gather list entries.
+ */
+enum {
+    UCT_IB_RX_SG_TL_HEADER_IDX = 0,
+    UCT_IB_RX_SG_PAYLOAD_IDX   = 1,
+    UCT_IB_RECV_SG_LIST_LEN
+};
+
+
+/**
  * IB port/path MTU.
  */
 typedef enum uct_ib_mtu {
@@ -325,8 +335,8 @@ UCS_CLASS_DECLARE(uct_ib_iface_t, uct_iface_ops_t*, uct_ib_iface_ops_t*,
  *                   |
  * uct_recv_desc_t   |
  *               |   |
- *               |   am_callback/tag_unexp_callback
- *               |   |
+ *               |               am_callback/tag_unexp_callback
+ *               |               |
  * +------+------+---+-----------+---------+
  * | LKey |  ??? | D | Head Room | Payload |
  * +------+------+---+--+--------+---------+
@@ -336,8 +346,8 @@ UCS_CLASS_DECLARE(uct_ib_iface_t, uct_iface_ops_t*, uct_ib_iface_ops_t*,
  *                      post_receive
  *
  * (2)
- *            am_callback/tag_unexp_callback
- *            |
+ *                               am_callback/tag_unexp_callback
+ *                               |
  * +------+---+------------------+---------+
  * | LKey | D |     Head Room    | Payload |
  * +------+---+-----+---+--------+---------+
@@ -352,17 +362,29 @@ UCS_CLASS_DECLARE(uct_ib_iface_t, uct_iface_ops_t*, uct_ib_iface_ops_t*,
  *
  */
 typedef struct uct_ib_iface_recv_desc {
-    uint32_t                lkey;
+    uint32_t header_lkey;  /* Header buffer lkey */
+    uint32_t payload_lkey; /* Payload buffer lkey */
+    void     *payload;     /* Point to the message payload buffer */
 } UCS_S_PACKED uct_ib_iface_recv_desc_t;
-
 
 
 extern ucs_config_field_t uct_ib_iface_config_table[];
 extern const char *uct_ib_mtu_values[];
 
 
+void uct_ib_iface_recv_desc_init(uct_iface_h tl_iface, void *obj,
+                                 uct_mem_h memh);
+
+
+ucs_status_t uct_ib_iface_recv_mpool_init_common(
+        uct_ib_iface_t *iface, const uct_ib_iface_config_t *config,
+        const uct_iface_params_t *params, size_t alignment_size,
+        size_t alignment_offset, size_t alignment_payload_offset,
+        size_t mpool_elem_size, const char *name, ucs_mpool_t *mp);
+
 /**
- * Create memory pool of receive descriptors.
+ * Create memory pool of receive descriptors with contiguous
+ * rx buffer (header+payload).
  */
 ucs_status_t uct_ib_iface_recv_mpool_init(uct_ib_iface_t *iface,
                                           const uct_ib_iface_config_t *config,
@@ -632,6 +654,13 @@ static UCS_F_ALWAYS_INLINE
 size_t uct_ib_iface_hdr_size(size_t max_inline, size_t min_size)
 {
     return (size_t)ucs_max((ssize_t)(max_inline - min_size), 0);
+}
+
+static UCS_F_ALWAYS_INLINE size_t
+uct_ib_iface_tl_hdr_length(uct_ib_iface_t *iface)
+{
+    return iface->config.rx_payload_offset - iface->config.rx_hdr_offset +
+           iface->super.rx_allocator.header_length;
 }
 
 static UCS_F_ALWAYS_INLINE void

--- a/src/uct/ib/mlx5/ib_mlx5.h
+++ b/src/uct/ib/mlx5/ib_mlx5.h
@@ -40,6 +40,7 @@
 #include <string.h>
 
 
+#define UCT_IB_MLX5_TERMINATE_SCATTER_LIST_MKEY 0x100
 #define UCT_IB_MLX5_WQE_SEG_SIZE         16 /* Size of a segment in a WQE */
 #define UCT_IB_MLX5_CQE64_MAX_INL        32 /* Inline scatter size in 64-byte CQE */
 #define UCT_IB_MLX5_CQE128_MAX_INL       64 /* Inline scatter size in 128-byte CQE */
@@ -694,10 +695,11 @@ ucs_status_t uct_ib_mlx5_get_rxwq(struct ibv_qp *qp, uct_ib_mlx5_rxwq_t *wq);
  */
 ucs_status_t
 uct_ib_mlx5_verbs_srq_init(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs_srq,
-                           size_t sg_byte_count, int num_sge);
+                           const size_t *sg_byte_count, int num_sge);
 
 void uct_ib_mlx5_srq_buff_init(uct_ib_mlx5_srq_t *srq, uint32_t head,
-                               uint32_t tail, size_t sg_byte_count, int num_sge);
+                               uint32_t tail, const size_t *sg_byte_count,
+                               int num_sge);
 
 void uct_ib_mlx5_verbs_srq_cleanup(uct_ib_mlx5_srq_t *srq, struct ibv_srq *verbs_srq);
 

--- a/src/uct/ib/rc/accel/rc_mlx5.inl
+++ b/src/uct/ib/rc/accel/rc_mlx5.inl
@@ -92,10 +92,14 @@ uct_rc_mlx5_iface_hold_srq_desc(uct_rc_mlx5_iface_common_t *iface,
         uct_recv_desc(udesc) = release_desc;
         seg->srq.ptr_mask   &= ~UCS_BIT(stride_idx);
     } else {
-        udesc                = UCS_PTR_BYTE_OFFSET(seg->srq.desc, offset);
-        uct_recv_desc(udesc) = release_desc;
-        seg->srq.ptr_mask   &= ~1;
-        seg->srq.desc        = NULL;
+        /* User callback takes ownership of the payload so we must replace it */
+        seg->srq.ptr_mask &= ~UCS_BIT(UCT_IB_RX_SG_PAYLOAD_IDX);
+        if (!iface->super.super.super.rx_allocator.user_allocator) {
+            udesc                = UCS_PTR_BYTE_OFFSET(seg->srq.desc, offset);
+            uct_recv_desc(udesc) = release_desc;
+            seg->srq.ptr_mask &= ~UCS_BIT(UCT_IB_RX_SG_TL_HEADER_IDX);
+            seg->srq.desc = NULL;
+        }
     }
 }
 
@@ -400,9 +404,12 @@ uct_rc_mlx5_iface_common_am_handler(uct_rc_mlx5_iface_common_t *iface,
     uct_ib_mlx5_srq_seg_t *seg;
     uint32_t qp_num;
     ucs_status_t status;
+    uct_am_callback_params_t params;
 
-    wqe_ctr = ntohs(cqe->wqe_counter);
-    seg     = uct_ib_mlx5_srq_get_wqe(&iface->rx.srq, wqe_ctr);
+    wqe_ctr           = ntohs(cqe->wqe_counter);
+    seg               = uct_ib_mlx5_srq_get_wqe(&iface->rx.srq, wqe_ctr);
+    params.field_mask = UCT_AM_CALLBACK_PARAM_FIELD_PAYLOAD;
+    params.payload    = seg->srq.desc->payload;
 
     uct_ib_mlx5_log_rx(&iface->super.super, cqe, hdr,
                        uct_rc_mlx5_common_packet_dump);
@@ -412,13 +419,15 @@ uct_rc_mlx5_iface_common_am_handler(uct_rc_mlx5_iface_common_t *iface,
         rc_ops = ucs_derived_of(iface->super.super.ops, uct_rc_iface_ops_t);
 
         /* coverity[overrun-buffer-val] */
-        status = rc_ops->fc_handler(&iface->super, qp_num, &hdr->rc_hdr,
+        status = rc_ops->fc_handler(&iface->super, qp_num,
+                                    &hdr->rc_hdr,
                                     byte_len - sizeof(*hdr),
-                                    cqe->imm_inval_pkey, cqe->slid, flags);
+                                    cqe->imm_inval_pkey, cqe->slid, flags,
+                                    &params);
     } else {
-        status = uct_iface_invoke_am(&iface->super.super.super, hdr->rc_hdr.am_id,
-                                     hdr + 1, byte_len - sizeof(*hdr),
-                                     flags, NULL);
+        status = uct_iface_invoke_am(&iface->super.super.super,
+                                     hdr->rc_hdr.am_id, hdr + 1,
+                                     byte_len - sizeof(*hdr), flags, &params);
     }
 
     uct_rc_mlx5_iface_release_srq_seg(iface, seg, cqe, wqe_ctr, status,
@@ -1410,6 +1419,183 @@ uct_rc_mlx5_iface_handle_filler_cqe(uct_rc_mlx5_iface_common_t *iface,
 }
 #endif /* IBV_HW_TM */
 
+/**
+ * Check if rx_allocator cache is empty
+ */
+static UCS_F_ALWAYS_INLINE int
+uct_rc_mlx5_rx_allocator_is_empty(uct_base_iface_t *base_iface)
+{
+    return base_iface->rx_allocator.cache.ready_idx ==
+           base_iface->rx_allocator.cache.available;
+}
+
+/**
+ * Call rx allocator cb to fill the rx_allocator cache
+ * with new available buffers.
+ */
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rc_mlx5_rx_allocator_get_buffers(uct_base_iface_t *base_iface)
+{
+    size_t num_allocated;
+
+    ucs_assert(uct_rc_mlx5_rx_allocator_is_empty(base_iface));
+
+    num_allocated = base_iface->rx_allocator.allocator.cb(
+            base_iface->rx_allocator.allocator.arg, UCT_ALLOCATOR_MAX_RX_BUFFS,
+            &base_iface->rx_allocator.cache.memh,
+            base_iface->rx_allocator.cache.buffers);
+
+    base_iface->rx_allocator.cache.ready_idx = 0;
+    base_iface->rx_allocator.cache.available = num_allocated;
+
+    if (ucs_unlikely(uct_rc_mlx5_rx_allocator_is_empty(base_iface))) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    return UCS_OK;
+}
+
+/**
+ * Return buffer from the rx_allocator cache
+ */
+static UCS_F_ALWAYS_INLINE void *
+uct_rc_mlx5_rx_allocator_get_buffer(uct_base_iface_t *base_iface)
+{
+    void *buff;
+
+    if (ucs_unlikely(uct_rc_mlx5_rx_allocator_is_empty(base_iface))) {
+        return NULL;
+    }
+
+    buff = base_iface->rx_allocator.cache
+                   .buffers[base_iface->rx_allocator.cache.ready_idx];
+    base_iface->rx_allocator.cache.ready_idx++;
+    return buff;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t uct_rc_mlx5_iface_common_srq_set_seg(
+        uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_srq_seg_t *seg)
+{
+    uct_ib_iface_recv_desc_t *desc;
+    uint64_t desc_map;
+    void *hdr;
+    int i;
+
+    desc_map = ~seg->srq.ptr_mask & UCS_MASK(iface->tm.mp.num_strides);
+    ucs_for_each_bit(i, desc_map) {
+        UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
+                                 desc, return UCS_ERR_NO_MEMORY);
+
+        /* Set receive data segment pointer. Length is pre-initialized. */
+        hdr = uct_ib_iface_recv_desc_hdr(&iface->super.super, desc);
+        seg->srq.ptr_mask |= UCS_BIT(i);
+        seg->srq.desc      = desc; /* Optimization for non-MP case (1 stride) */
+        seg->dptr[i].lkey  = htonl(desc->header_lkey);
+        seg->dptr[i].addr  = htobe64((uintptr_t)hdr);
+        VALGRIND_MAKE_MEM_NOACCESS(hdr, iface->super.super.config.seg_size);
+    }
+
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rc_mlx5_iface_common_seg_set_sge_header_entry(
+        uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_srq_seg_t *seg)
+{
+    uct_ib_iface_recv_desc_t *desc;
+    void *hdr;
+
+    UCT_TL_IFACE_GET_RX_DESC(&iface->super.super.super, &iface->super.rx.mp,
+                             desc, return UCS_ERR_NO_MEMORY);
+    hdr           = uct_ib_iface_recv_desc_hdr(&iface->super.super, desc);
+    seg->srq.desc = desc;
+
+    seg->srq.ptr_mask |= UCS_BIT(UCT_IB_RX_SG_TL_HEADER_IDX);
+    seg->dptr[UCT_IB_RX_SG_TL_HEADER_IDX].lkey = htonl(desc->header_lkey);
+    seg->dptr[UCT_IB_RX_SG_TL_HEADER_IDX].addr = htobe64((uintptr_t)hdr);
+
+    VALGRIND_MAKE_MEM_NOACCESS(hdr,
+                               uct_ib_iface_tl_hdr_length(&iface->super.super));
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rc_mlx5_iface_common_seg_set_sge_payload_entry(
+        uct_rc_mlx5_iface_common_t *iface, uct_ib_mlx5_srq_seg_t *seg)
+{
+    uct_base_iface_t *base_iface   = &iface->super.super.super;
+    uct_ib_iface_recv_desc_t *desc = seg->srq.desc;
+
+    desc->payload = uct_rc_mlx5_rx_allocator_get_buffer(base_iface);
+    if (ucs_unlikely(desc->payload == NULL)) {
+        return UCS_ERR_NO_MEMORY;
+    }
+
+    desc->payload_lkey = uct_ib_memh_get_lkey(
+            base_iface->rx_allocator.cache.memh);
+
+    seg->srq.ptr_mask |= UCS_BIT(UCT_IB_RX_SG_PAYLOAD_IDX);
+    seg->dptr[UCT_IB_RX_SG_PAYLOAD_IDX].lkey = htonl(desc->payload_lkey);
+    seg->dptr[UCT_IB_RX_SG_PAYLOAD_IDX].addr = htobe64(
+            (uintptr_t)desc->payload);
+
+    VALGRIND_MAKE_MEM_NOACCESS(desc->payload,
+                               base_iface->rx_allocator.payload_length);
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE ucs_status_t
+uct_rc_mlx5_iface_common_srq_set_seg_sge(uct_rc_mlx5_iface_common_t *iface,
+                                         uct_ib_mlx5_srq_seg_t *seg)
+{
+    uct_base_iface_t *base_iface = &iface->super.super.super;
+    uint64_t desc_map;
+    ucs_status_t status;
+
+    desc_map = ~seg->srq.ptr_mask & UCS_MASK(UCT_IB_RECV_SG_LIST_LEN);
+    if (!desc_map) {
+        return UCS_OK;
+    }
+
+    if (uct_rc_mlx5_rx_allocator_is_empty(base_iface)) {
+        status = uct_rc_mlx5_rx_allocator_get_buffers(base_iface);
+        if (ucs_unlikely(status != UCS_OK)) {
+            return status;
+        }
+    }
+
+    if (desc_map & UCS_BIT(UCT_IB_RX_SG_TL_HEADER_IDX)) {
+        status = uct_rc_mlx5_iface_common_seg_set_sge_header_entry(iface, seg);
+        if (ucs_unlikely(status != UCS_OK)) {
+            return status;
+        }
+    }
+
+    if (desc_map & UCS_BIT(UCT_IB_RX_SG_PAYLOAD_IDX)) {
+        /*
+         * No need to check for the return status here.
+         * RX Allocator cache contains at least one free buffer.
+         * We know that because before entering this branch we filled
+         * the cache with new buffers and checked the return status.
+         */
+        uct_rc_mlx5_iface_common_seg_set_sge_payload_entry(iface, seg);
+    }
+
+    return UCS_OK;
+}
+
+static UCS_F_ALWAYS_INLINE void
+uct_rc_mlx5_iface_srq_post_recv_common(uct_rc_mlx5_iface_common_t *iface)
+{
+    if (ucs_likely(!UCT_RC_MLX5_MP_ENABLED(iface))) {
+        uct_rc_mlx5_iface_srq_post_recv(
+                iface, uct_rc_mlx5_iface_common_srq_set_seg_sge);
+    } else {
+        uct_rc_mlx5_iface_srq_post_recv(iface,
+                                        uct_rc_mlx5_iface_common_srq_set_seg);
+    }
+}
+
 static UCS_F_ALWAYS_INLINE unsigned
 uct_rc_mlx5_iface_common_poll_rx(uct_rc_mlx5_iface_common_t *iface,
                                  int poll_flags)
@@ -1548,9 +1734,15 @@ out:
     max_batch = iface->super.super.config.rx_max_batch;
     if (ucs_unlikely(iface->super.rx.srq.available >= max_batch)) {
         if (poll_flags & UCT_RC_MLX5_POLL_FLAG_LINKED_LIST) {
-            uct_rc_mlx5_iface_srq_post_recv_ll(iface);
+            if (ucs_likely(!UCT_RC_MLX5_MP_ENABLED(iface))) {
+                uct_rc_mlx5_iface_srq_post_recv_ll(
+                        iface, uct_rc_mlx5_iface_common_srq_set_seg_sge);
+            } else {
+                uct_rc_mlx5_iface_srq_post_recv_ll(
+                        iface, uct_rc_mlx5_iface_common_srq_set_seg);
+            }
         } else {
-            uct_rc_mlx5_iface_srq_post_recv(iface);
+            uct_rc_mlx5_iface_srq_post_recv_common(iface);
         }
     }
     return count;
@@ -1820,3 +2012,19 @@ uct_rc_mlx5_iface_common_atomic_data(unsigned opcode, unsigned size, uint64_t va
     return UCS_OK;
 }
 
+static void UCS_F_ALWAYS_INLINE uct_ib_mlx5_srq_init_sg_byte_counts(
+        uct_rc_mlx5_iface_common_t *iface, size_t *sg_byte_count)
+{
+    int i;
+
+    if (UCT_RC_MLX5_MP_ENABLED(iface)) {
+        for (i = 0; i < iface->tm.mp.num_strides; ++i) {
+            sg_byte_count[i] = iface->super.super.config.seg_size;
+        }
+    } else {
+        sg_byte_count[UCT_IB_RX_SG_TL_HEADER_IDX] = uct_ib_iface_tl_hdr_length(
+                &iface->super.super);
+        sg_byte_count[UCT_IB_RX_SG_PAYLOAD_IDX] =
+                iface->super.super.super.rx_allocator.payload_length;
+    }
+}

--- a/src/uct/ib/rc/accel/rc_mlx5_common.h
+++ b/src/uct/ib/rc/accel/rc_mlx5_common.h
@@ -319,8 +319,8 @@ typedef struct uct_rc_mlx5_tmh_priv_data {
 void uct_rc_mlx5_release_desc(uct_recv_desc_t *self, void *desc);
 
 typedef struct uct_rc_mlx5_release_desc {
-    uct_recv_desc_t             super;
-    unsigned                    offset;
+    uct_recv_desc_t super;
+    int             offset;
 } uct_rc_mlx5_release_desc_t;
 
 
@@ -458,7 +458,8 @@ UCS_CLASS_DECLARE(uct_rc_mlx5_iface_common_t, uct_iface_ops_t*,
 
 #define UCT_RC_MLX5_TM_ENABLED(_iface) (_iface)->tm.enabled
 
-#define UCT_RC_MLX5_MP_ENABLED(_iface) ((_iface)->tm.mp.num_strides > 1)
+#define UCT_RC_MLX5_MP_ENABLED(_iface) \
+    ((_iface)->tm.mp.num_strides > UCT_IB_RECV_SG_LIST_LEN)
 
 /* TMH can carry 2 bytes of data in its reserved filed */
 #define UCT_RC_MLX5_TMH_PRIV_LEN       ucs_field_sizeof(uct_rc_mlx5_tmh_priv_data_t, \
@@ -577,8 +578,15 @@ uct_rc_mlx5_handle_rndv_fin(uct_rc_mlx5_iface_common_t *iface, uint32_t app_ctx)
 
 extern ucs_config_field_t uct_rc_mlx5_common_config_table[];
 
-unsigned uct_rc_mlx5_iface_srq_post_recv(uct_rc_mlx5_iface_common_t *iface);
-unsigned uct_rc_mlx5_iface_srq_post_recv_ll(uct_rc_mlx5_iface_common_t *iface);
+typedef ucs_status_t
+uct_rc_mlx5_iface_set_seg_func(uct_rc_mlx5_iface_common_t *iface,
+                               uct_ib_mlx5_srq_seg_t *seg);
+unsigned
+uct_rc_mlx5_iface_srq_post_recv(uct_rc_mlx5_iface_common_t *iface,
+                                uct_rc_mlx5_iface_set_seg_func set_seg);
+unsigned
+uct_rc_mlx5_iface_srq_post_recv_ll(uct_rc_mlx5_iface_common_t *iface,
+                                   uct_rc_mlx5_iface_set_seg_func set_seg);
 
 void uct_rc_mlx5_iface_common_prepost_recvs(uct_rc_mlx5_iface_common_t *iface);
 

--- a/src/uct/ib/rc/accel/rc_mlx5_devx.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_devx.c
@@ -146,6 +146,7 @@ uct_rc_mlx5_devx_init_rx_common(uct_rc_mlx5_iface_common_t *iface,
 {
     ucs_status_t status  = UCS_ERR_NO_MEMORY;
     int len, max, stride, log_num_of_strides, wq_type;
+    size_t sg_byte_count[16];
 
     stride = uct_ib_mlx5_srq_stride(iface->tm.mp.num_strides);
     max    = uct_ib_mlx5_srq_max_wrs(config->super.rx.queue_len,
@@ -196,8 +197,9 @@ uct_rc_mlx5_devx_init_rx_common(uct_rc_mlx5_iface_common_t *iface,
     }
 
     iface->rx.srq.type = UCT_IB_MLX5_OBJ_TYPE_DEVX;
+    uct_ib_mlx5_srq_init_sg_byte_counts(iface, sg_byte_count);
     uct_ib_mlx5_srq_buff_init(&iface->rx.srq, 0, max - 1,
-                              iface->super.super.config.seg_size,
+                              sg_byte_count,
                               iface->tm.mp.num_strides);
     iface->super.rx.srq.quota = max - 1;
 

--- a/src/uct/ib/rc/accel/rc_mlx5_iface.c
+++ b/src/uct/ib/rc/accel/rc_mlx5_iface.c
@@ -555,7 +555,7 @@ out_tm_disabled:
 #endif
     init_attr->cq_len[UCT_IB_DIR_RX] = rc_config->super.rx.queue_len;
     init_attr->seg_size              = rc_config->super.seg_size;
-    iface->tm.mp.num_strides         = 1;
+    iface->tm.mp.num_strides         = UCT_IB_RECV_SG_LIST_LEN;
 
 #if IBV_HW_TM
 out_mp_disabled:
@@ -718,6 +718,8 @@ UCS_CLASS_INIT_FUNC(uct_rc_mlx5_iface_common_t, uct_iface_ops_t *tl_ops,
     if (status != UCS_OK) {
         return status;
     }
+
+    ucs_assertv(!UCT_RC_MLX5_MP_ENABLED(self), "Tag matching is not supported\n");
 
     self->rx.srq.type                = UCT_IB_MLX5_OBJ_TYPE_LAST;
     self->tm.cmd_wq.super.super.type = UCT_IB_MLX5_OBJ_TYPE_LAST;

--- a/src/uct/ib/rc/base/rc_iface.c
+++ b/src/uct/ib/rc/base/rc_iface.c
@@ -28,7 +28,8 @@ static const char *uct_rc_fence_mode_values[] = {
 };
 
 ucs_config_field_t uct_rc_iface_common_config_table[] = {
-  {UCT_IB_CONFIG_PREFIX, "RX_INLINE=64;TX_INLINE_RESP=64;RX_QUEUE_LEN=4095;SEG_SIZE=8256", NULL,
+  /* Scatter2CQE is not supported by new AM handlers handling non contiguous rx descriptor. */
+  {UCT_IB_CONFIG_PREFIX, "RX_INLINE=0;TX_INLINE_RESP=64;RX_QUEUE_LEN=4095;SEG_SIZE=8256", NULL,
    ucs_offsetof(uct_rc_iface_common_config_t, super),
    UCS_CONFIG_TYPE_TABLE(uct_ib_iface_config_table)},
 
@@ -351,7 +352,9 @@ ucs_status_t uct_rc_init_fc_thresh(uct_rc_iface_config_t *config,
 
 ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
                                      uct_rc_hdr_t *hdr, unsigned length,
-                                     uint32_t imm_data, uint16_t lid, unsigned flags)
+                                     uint32_t imm_data, uint16_t lid,
+                                     unsigned flags,
+                                     uct_am_callback_params_t *params)
 {
     ucs_status_t status;
     int16_t      cur_wnd;
@@ -427,8 +430,8 @@ ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
 
 out:
     return uct_iface_invoke_am(&iface->super.super,
-                               (hdr->am_id & ~UCT_RC_EP_FC_MASK),
-                               hdr + 1, length, flags, NULL);
+                               (hdr->am_id & ~UCT_RC_EP_FC_MASK), hdr + 1,
+                               length, flags, params);
 }
 
 static ucs_status_t uct_rc_iface_tx_ops_init(uct_rc_iface_t *iface)
@@ -499,7 +502,7 @@ ucs_status_t uct_rc_iface_init_rx(uct_rc_iface_t *iface,
     struct ibv_pd *pd = uct_ib_iface_md(&iface->super)->pd;
     struct ibv_srq *srq;
 
-    srq_init_attr.attr.max_sge   = 1;
+    srq_init_attr.attr.max_sge   = UCT_IB_RECV_SG_LIST_LEN;
     srq_init_attr.attr.max_wr    = config->super.rx.queue_len;
     srq_init_attr.attr.srq_limit = 0;
     srq_init_attr.srq_context    = iface;
@@ -554,6 +557,20 @@ uct_rc_iface_init_max_rd_atomic(uct_rc_iface_t *iface,
     }
 
     return UCS_OK;
+}
+
+static ucs_status_t
+uct_rc_iface_recv_mpool_init(uct_ib_iface_t *iface,
+                             const uct_ib_iface_config_t *config,
+                             const uct_iface_params_t *params, const char *name,
+                             ucs_mpool_t *tl_hdr_mpool)
+{
+    return uct_ib_iface_recv_mpool_init_common(
+            iface, config, params, iface->config.rx_payload_offset, 0,
+            iface->config.rx_hdr_offset,
+            iface->config.rx_payload_offset +
+                    iface->super.rx_allocator.header_length,
+            name, tl_hdr_mpool);
 }
 
 UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
@@ -652,9 +669,9 @@ UCS_CLASS_INIT_FUNC(uct_rc_iface_t, uct_iface_ops_t *tl_ops,
         goto err;
     }
 
-    /* Create RX buffers mempool */
-    status = uct_ib_iface_recv_mpool_init(&self->super, &config->super, params,
-                                          "rc_recv_desc", &self->rx.mp);
+    /* Create RX buffers mempool For SGE*/
+    status = uct_rc_iface_recv_mpool_init(&self->super, &config->super, params,
+                                          "rc_recv_tl_hdr", &self->rx.mp);
     if (status != UCS_OK) {
         goto err;
     }
@@ -819,7 +836,7 @@ void uct_rc_iface_fill_attr(uct_rc_iface_t *iface, uct_ib_qp_attr_t *attr,
     attr->cap.max_send_wr            = max_send_wr;
     attr->cap.max_recv_wr            = 0;
     attr->cap.max_send_sge           = iface->config.tx_min_sge;
-    attr->cap.max_recv_sge           = 1;
+    attr->cap.max_recv_sge           = UCT_IB_RECV_SG_LIST_LEN;
     attr->cap.max_inline_data        = iface->config.tx_min_inline;
     attr->qp_type                    = iface->super.config.qp_type;
     attr->sq_sig_all                 = !iface->config.tx_moderation;

--- a/src/uct/ib/rc/base/rc_iface.h
+++ b/src/uct/ib/rc/base/rc_iface.h
@@ -197,13 +197,10 @@ typedef void (*uct_rc_iface_cleanup_rx_func_t)(uct_rc_iface_t *iface);
 typedef ucs_status_t (*uct_rc_iface_fc_ctrl_func_t)(uct_ep_t *ep, unsigned op,
                                                     uct_rc_pending_req_t *req);
 
-typedef ucs_status_t (*uct_rc_iface_fc_handler_func_t)(uct_rc_iface_t *iface,
-                                                       unsigned qp_num,
-                                                       uct_rc_hdr_t *hdr,
-                                                       unsigned length,
-                                                       uint32_t imm_data,
-                                                       uint16_t lid,
-                                                       unsigned flags);
+typedef ucs_status_t (*uct_rc_iface_fc_handler_func_t)(
+        uct_rc_iface_t *iface, unsigned qp_num, uct_rc_hdr_t *hdr,
+        unsigned length, uint32_t imm_data, uint16_t lid, unsigned flags,
+        uct_am_callback_params_t *params);
 
 typedef void (*uct_rc_iface_qp_cleanup_func_t)(
         uct_rc_iface_qp_cleanup_ctx_t *cleanup_ctx);
@@ -259,7 +256,9 @@ struct uct_rc_iface {
     } tx;
 
     struct {
+        /*tl header buffers mpool*/
         ucs_mpool_t          mp;
+
         uct_rc_srq_t         srq;
     } rx;
 
@@ -409,7 +408,9 @@ ucs_status_t uct_rc_iface_qp_connect(uct_rc_iface_t *iface, struct ibv_qp *qp,
 
 ucs_status_t uct_rc_iface_fc_handler(uct_rc_iface_t *iface, unsigned qp_num,
                                      uct_rc_hdr_t *hdr, unsigned length,
-                                     uint32_t imm_data, uint16_t lid, unsigned flags);
+                                     uint32_t imm_data, uint16_t lid,
+                                     unsigned flags,
+                                     uct_am_callback_params_t *params);
 
 ucs_status_t uct_rc_init_fc_thresh(uct_rc_iface_config_t *rc_cfg,
                                    uct_rc_iface_t *iface);

--- a/src/uct/ib/rc/verbs/rc_verbs_impl.h
+++ b/src/uct/ib/rc/verbs/rc_verbs_impl.h
@@ -56,11 +56,12 @@ uct_rc_verbs_iface_handle_am(uct_rc_iface_t *iface, uct_rc_hdr_t *hdr,
     ucs_status_t status;
     void *udesc;
 
-    desc = (uct_ib_iface_recv_desc_t *)wr_id;
+    desc = (uct_ib_iface_recv_desc_t*)wr_id;
     if (ucs_unlikely(hdr->am_id & UCT_RC_EP_FC_MASK)) {
         rc_ops = ucs_derived_of(iface->super.ops, uct_rc_iface_ops_t);
         status = rc_ops->fc_handler(iface, qp_num, hdr, length - sizeof(*hdr),
-                                    imm_data, slid, UCT_CB_PARAM_FLAG_DESC);
+                                    imm_data, slid, UCT_CB_PARAM_FLAG_DESC,
+                                    NULL);
     } else {
         status = uct_iface_invoke_am(&iface->super.super, hdr->am_id, hdr + 1,
                                      length - sizeof(*hdr),


### PR DESCRIPTION
## What
This branch contains the implementation of the user memory allocator feature and an App
with test example.

## Why ?
- Customer want to control the memory management.
- Receive data to "clean" buffers.
- Support signature offload

## How ?
- Use SGE list in RQ/SRQ
- Change AM Handlers API
- API changes to pass memory allocator by the App
- Test example that uses the new API

Follows #35 
